### PR TITLE
Empire Property Enhancements (SetMultiple, Default Null Values)

### DIFF
--- a/lib/empire_view_model.dart
+++ b/lib/empire_view_model.dart
@@ -193,7 +193,7 @@ abstract class EmpireViewModel {
   ///
   ///```
   EmpireProperty<T?> createNullProperty<T>({String? propertyName}) {
-    return EmpireProperty<T?>(null, this, propertyName: propertyName);
+    return createProperty(null, propertyName: propertyName);
   }
 
   ///Closes the state and error streams and removes any listeners associated with those streams

--- a/test/empire_view_model_test.dart
+++ b/test/empire_view_model_test.dart
@@ -1,0 +1,85 @@
+import 'package:empire/empire_state.dart';
+import 'package:empire/empire_view_model.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class _TestViewModel extends EmpireViewModel {
+  late EmpireProperty<String?> name;
+  late EmpireProperty<int> age;
+
+  @override
+  void initProperties() {
+    name = createNullProperty();
+    age = createProperty(1);
+  }
+
+  void useSetMultiple(String name, int age) {
+    setMultiple({
+      this.name: name,
+      this.age: age,
+    });
+  }
+}
+
+class _MyWidget extends EmpireWidget<_TestViewModel> {
+  const _MyWidget({
+    Key? key,
+    required _TestViewModel viewModel,
+  }) : super(key: key, viewModel: viewModel);
+
+  @override
+  EmpireState<EmpireWidget<EmpireViewModel>, _TestViewModel> createEmpire() {
+    return _MyWidgetState(viewModel);
+  }
+}
+
+class _MyWidgetState extends EmpireState<_MyWidget, _TestViewModel> {
+  _MyWidgetState(super.viewModel);
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      home: Scaffold(
+        body: Builder(
+          builder: (innerContext) {
+            return Center(
+              child: Column(
+                children: [
+                  Text(viewModel.name.value ?? ''),
+                  Text(
+                    viewModel.age.value.toString(),
+                  )
+                ],
+              ),
+            );
+          },
+        ),
+      ),
+    );
+  }
+}
+
+void main() {
+  testWidgets('SetMultiple - All Widgets Update After Multiple Set', (tester) async {
+    final viewModel = _TestViewModel();
+    viewModel.name('Justin');
+    viewModel.age(88);
+
+    await tester.pumpWidget(_MyWidget(
+      viewModel: viewModel,
+    ));
+
+    expect(find.text("Justin"), findsOneWidget);
+    expect(find.text("88"), findsOneWidget);
+
+    const newName = 'Mike';
+    const newAge = 20;
+
+    viewModel.useSetMultiple(newName, newAge);
+
+    await tester.pumpAndSettle();
+
+    expect(find.text(newName), findsOneWidget);
+    expect(find.text(newAge.toString()), findsOneWidget);
+  });
+}

--- a/test/empire_view_model_test.dart
+++ b/test/empire_view_model_test.dart
@@ -1,6 +1,4 @@
-import 'package:empire/empire_state.dart';
 import 'package:empire/empire_view_model.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 class _TestViewModel extends EmpireViewModel {
@@ -21,65 +19,26 @@ class _TestViewModel extends EmpireViewModel {
   }
 }
 
-class _MyWidget extends EmpireWidget<_TestViewModel> {
-  const _MyWidget({
-    Key? key,
-    required _TestViewModel viewModel,
-  }) : super(key: key, viewModel: viewModel);
-
-  @override
-  EmpireState<EmpireWidget<EmpireViewModel>, _TestViewModel> createEmpire() {
-    return _MyWidgetState(viewModel);
-  }
-}
-
-class _MyWidgetState extends EmpireState<_MyWidget, _TestViewModel> {
-  _MyWidgetState(super.viewModel);
-
-  @override
-  Widget build(BuildContext context) {
-    return MaterialApp(
-      home: Scaffold(
-        body: Builder(
-          builder: (innerContext) {
-            return Center(
-              child: Column(
-                children: [
-                  Text(viewModel.name.value ?? ''),
-                  Text(
-                    viewModel.age.value.toString(),
-                  )
-                ],
-              ),
-            );
-          },
-        ),
-      ),
-    );
-  }
-}
-
 void main() {
-  testWidgets('SetMultiple - All Widgets Update After Multiple Set', (tester) async {
-    final viewModel = _TestViewModel();
-    viewModel.name('Justin');
-    viewModel.age(88);
+  group('SetMultiple Tests', () {
+    test('createNullProperty - Value is Null', () {
+      final viewModel = _TestViewModel();
+      final EmpireProperty<int?> age = viewModel.createNullProperty();
+      expect(age.value, isNull);
+    });
 
-    await tester.pumpWidget(_MyWidget(
-      viewModel: viewModel,
-    ));
+    test('createProperty - passed value equals property value', () {
+      final viewModel = _TestViewModel();
+      const expectedValue = 10;
+      final EmpireProperty<int> age = viewModel.createProperty(expectedValue);
+      expect(age.value, equals(expectedValue));
+    });
 
-    expect(find.text("Justin"), findsOneWidget);
-    expect(find.text("88"), findsOneWidget);
-
-    const newName = 'Mike';
-    const newAge = 20;
-
-    viewModel.useSetMultiple(newName, newAge);
-
-    await tester.pumpAndSettle();
-
-    expect(find.text(newName), findsOneWidget);
-    expect(find.text(newAge.toString()), findsOneWidget);
+    test('createProperty - set optional property name', () {
+      final viewModel = _TestViewModel();
+      const expectedValue = 'age';
+      final EmpireProperty<int> age = viewModel.createProperty(10, propertyName: expectedValue);
+      expect(age.propertyName, equals(expectedValue));
+    });
   });
 }

--- a/test/empire_widget_test.dart
+++ b/test/empire_widget_test.dart
@@ -68,7 +68,7 @@ class _MyWidgetState extends EmpireState<MyWidget, TestViewModel> {
 }
 
 void main() {
-  testWidgets('Test', (tester) async {
+  testWidgets('EmpireWidget Test - Finds Correct Text Widget After Property Change', (tester) async {
     final viewModel = TestViewModel();
     final appViewModel = ApplicationViewModel();
     viewModel.name("Justin");
@@ -87,7 +87,7 @@ void main() {
     expect(textTwo, findsOneWidget);
   });
 
-  testWidgets('Test Application', (tester) async {
+  testWidgets('Empire App State Test - Widgets Update on App View Model Change', (tester) async {
     final viewModel = TestViewModel();
     final appViewModel = ApplicationViewModel();
     await tester.pumpWidget(MyWidget(


### PR DESCRIPTION
Resolves #7 

- Can now set multiple `EmpireProperty` objects while only notifying the UI a single time, after all the changes have been made.
- Added a function, `createNullProperty` that creates an `EmpireProperty` object whose generic type argument is Nullable and defaults the internal value to null.
