### PR TITLE
Add Reset Feature to EmpireProperty

### DIFF
--- a/lib/empire_view_model.dart
+++ b/lib/empire_view_model.dart
@@ -252,12 +252,15 @@ abstract class EmpireValue<T> {
 class EmpireProperty<T> implements EmpireValue<T> {
   String? propertyName;
   T _value;
+  late final T _originalValue;
   @override
   T get value => _value;
 
   final EmpireViewModel _viewModel;
 
-  EmpireProperty(this._value, this._viewModel, {this.propertyName});
+  EmpireProperty(this._value, this._viewModel, {this.propertyName}) {
+    _originalValue = _value;
+  }
 
   void call(T value, {bool notifyChange = true}) {
     set(value, notifyChange: notifyChange);
@@ -269,6 +272,35 @@ class EmpireProperty<T> implements EmpireValue<T> {
     _value = value;
     if (notifyChange) {
       _viewModel.notifyChanges([EmpireStateChanged(value, previousValue, propertyName: propertyName)]);
+    }
+  }
+
+  ///Resets the value to what it was initialized with.
+  ///
+  ///## Usage
+  ///
+  ///```dart
+  ///late final EmpireProperty<int> age = createProperty(10); //age.value is 10
+  ///
+  ///age(20); //age.value is 20
+  ///age(25); //age.value is 25
+  ///
+  ///age.reset(); //age.value is back to 10. Triggers UI rebuild or...
+  ///
+  ///age.reset(notifyChange: false); //age.value is back to 10 but UI does not rebuild
+  ///```
+  void reset({bool notifyChange = true}) {
+    final currentValue = _value;
+    _value = _originalValue;
+
+    if (notifyChange) {
+      _viewModel.notifyChanges([
+        EmpireStateChanged(
+          _originalValue,
+          currentValue,
+          propertyName: propertyName,
+        )
+      ]);
     }
   }
 

--- a/test/empire_property_test.dart
+++ b/test/empire_property_test.dart
@@ -1,0 +1,96 @@
+import 'package:empire/empire.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class _TestViewModel extends EmpireViewModel {
+  late EmpireProperty<String?> name;
+  late EmpireProperty<int> age;
+
+  @override
+  void initProperties() {
+    name = createNullProperty();
+    age = createProperty(1);
+  }
+}
+
+class _MyWidget extends EmpireWidget<_TestViewModel> {
+  const _MyWidget({
+    Key? key,
+    required _TestViewModel viewModel,
+  }) : super(key: key, viewModel: viewModel);
+
+  @override
+  EmpireState<EmpireWidget<EmpireViewModel>, _TestViewModel> createEmpire() {
+    return _MyWidgetState(viewModel);
+  }
+}
+
+class _MyWidgetState extends EmpireState<_MyWidget, _TestViewModel> {
+  _MyWidgetState(super.viewModel);
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      home: Scaffold(
+        body: Builder(
+          builder: (innerContext) {
+            return Center(
+              child: Column(
+                children: [
+                  Text(viewModel.name.value ?? ''),
+                  Text(viewModel.age.toString()),
+                ],
+              ),
+            );
+          },
+        ),
+      ),
+    );
+  }
+}
+
+void main() {
+  late _TestViewModel viewModel;
+  late _MyWidget testWidget;
+  setUp(() {
+    viewModel = _TestViewModel();
+    testWidget = _MyWidget(viewModel: viewModel);
+  });
+  group('Property Reset Tests', () {
+    testWidgets('reset - notifyChange is true - UI Updates', (tester) async {
+      await tester.pumpWidget(testWidget);
+
+      expect(find.text("1"), findsOneWidget);
+
+      viewModel.age(10);
+
+      await tester.pumpAndSettle();
+
+      expect(find.text("10"), findsOneWidget);
+
+      viewModel.age.reset();
+
+      await tester.pumpAndSettle();
+
+      expect(find.text("1"), findsOneWidget);
+    });
+
+    testWidgets('reset - notifyChange is false - UI Does Not Update', (tester) async {
+      await tester.pumpWidget(testWidget);
+
+      expect(find.text("1"), findsOneWidget);
+
+      viewModel.age(10);
+
+      await tester.pumpAndSettle();
+
+      expect(find.text("10"), findsOneWidget);
+
+      viewModel.age.reset(notifyChange: false);
+
+      await tester.pumpAndSettle();
+
+      expect(find.text("10"), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
Resolves #11 

- Added reset function to EmpireProperty. Calling this will reset the property value to what it was initialized with. By default, this will publish a change event, however, you can override this by passing `notifyChange: false` as an argument.