### PR TITLE
EmpireProperty Equality Check Improvements

### DIFF
--- a/lib/empire_view_model.dart
+++ b/lib/empire_view_model.dart
@@ -315,11 +315,13 @@ class EmpireProperty<T> implements EmpireValue<T> {
   ///final EmpireProperty<int> age = createProperty(10);
   ///
   ///age.equals(10); //returns true
+  ///
+  ///
+  ///final EmpireProperty<int> ageTwo = createProperty(10);
+  ///
+  ///age.equals(ageTwo); //returns true
   ///```
-  bool equals(T other) => _value == other;
-
-  @override
-  bool operator ==(dynamic other) {
+  bool equals(dynamic other) {
     if (other is EmpireProperty) {
       return other.value == value;
     } else if (other is T) {
@@ -328,6 +330,9 @@ class EmpireProperty<T> implements EmpireValue<T> {
       return false;
     }
   }
+
+  @override
+  bool operator ==(dynamic other) => equals(other);
 
   @override
   int get hashCode => _value.hashCode;

--- a/lib/empire_view_model.dart
+++ b/lib/empire_view_model.dart
@@ -274,6 +274,31 @@ class EmpireProperty<T> implements EmpireValue<T> {
 
   @override
   String toString() => _value?.toString() ?? '';
+
+  ///Checks if [other] is equal to the [value] of this EmpireProperty
+  ///
+  ///### Usage
+  ///
+  ///```dart
+  ///final EmpireProperty<int> age = createProperty(10);
+  ///
+  ///age.equals(10); //returns true
+  ///```
+  bool equals(T other) => _value == other;
+
+  @override
+  bool operator ==(dynamic other) {
+    if (other is EmpireProperty) {
+      return other.value == value;
+    } else if (other is T) {
+      return other == value;
+    } else {
+      return false;
+    }
+  }
+
+  @override
+  int get hashCode => _value.hashCode;
 }
 
 ///The event that is added to the State stream.

--- a/lib/empire_view_model.dart
+++ b/lib/empire_view_model.dart
@@ -324,10 +324,8 @@ class EmpireProperty<T> implements EmpireValue<T> {
   bool equals(dynamic other) {
     if (other is EmpireProperty) {
       return other.value == value;
-    } else if (other is T) {
-      return other == value;
     } else {
-      return false;
+      return other == value;
     }
   }
 

--- a/test/empire_property_test.dart
+++ b/test/empire_property_test.dart
@@ -1,0 +1,70 @@
+import 'package:empire/empire.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class _TestViewModel extends EmpireViewModel {
+  @override
+  void initProperties() {}
+}
+
+void main() {
+  late _TestViewModel viewModel;
+  setUp(() {
+    viewModel = _TestViewModel();
+  });
+
+  group('EmpireProperty Equality Tests', () {
+    test('equals - other is same value - are equal', () {
+      final EmpireProperty<int> ageOne = viewModel.createProperty(10);
+      const int ageTwo = 10;
+
+      expect(ageOne.equals(ageTwo), isTrue);
+    });
+
+    test('equals - other is different value - are not equal', () {
+      final EmpireProperty<int> ageOne = viewModel.createProperty(10);
+      const int ageTwo = 5;
+
+      expect(ageOne.equals(ageTwo), isFalse);
+    });
+
+    test('equality - other is EmpireProperty with same value - are equal', () {
+      final EmpireProperty<int> ageOne = viewModel.createProperty(10);
+      final EmpireProperty<int> ageTwo = viewModel.createProperty(10);
+
+      expect(ageOne == ageTwo, isTrue);
+    });
+
+    test('equality - other is EmpireProperty with different value - are not equal', () {
+      final EmpireProperty<int> ageOne = viewModel.createProperty(10);
+      final EmpireProperty<int> ageTwo = viewModel.createProperty(5);
+
+      expect(ageOne == ageTwo, isFalse);
+    });
+
+    test('equality - other is same as EmpireProperty generic type argument with same value - are equal', () {
+      final EmpireProperty<int> ageOne = viewModel.createProperty(10);
+      const int ageTwo = 10;
+
+      // ignore: unrelated_type_equality_checks
+      expect(ageOne == ageTwo, isTrue);
+    });
+
+    test(
+        'equality - other is same as EmpireProperty generic type argument with different value - are not equal',
+        () {
+      final EmpireProperty<int> ageOne = viewModel.createProperty(10);
+      const int ageTwo = 5;
+
+      // ignore: unrelated_type_equality_checks
+      expect(ageOne == ageTwo, isFalse);
+    });
+
+    test('equality - other is not EmpireProperty or generic type argument - are not equal', () {
+      final EmpireProperty<int> ageOne = viewModel.createProperty(10);
+      const String name = 'Bob';
+
+      // ignore: unrelated_type_equality_checks
+      expect(ageOne == name, isFalse);
+    });
+  });
+}

--- a/test/empire_property_test.dart
+++ b/test/empire_property_test.dart
@@ -72,6 +72,27 @@ void main() {
       expect(ageOne.equals(ageTwo), isFalse);
     });
 
+    test('equals - other is EmpireProperty with same value - are equal', () {
+      final EmpireProperty<int> ageOne = viewModel.createProperty(10);
+      final EmpireProperty<int> ageTwo = viewModel.createProperty(10);
+
+      expect(ageOne.equals(ageTwo), isTrue);
+    });
+
+    test('equals - other is EmpireProperty with different value - are not equal', () {
+      final EmpireProperty<int> ageOne = viewModel.createProperty(10);
+      final EmpireProperty<int> ageTwo = viewModel.createProperty(5);
+
+      expect(ageOne.equals(ageTwo), isFalse);
+    });
+
+    test('equals - other is EmpireProperty with same value - are equal', () {
+      final EmpireProperty<int> ageOne = viewModel.createProperty(10);
+      const double ageTwo = 10.0;
+
+      expect(ageOne.equals(ageTwo), isTrue);
+    });
+
     test('equality - other is EmpireProperty with same value - are equal', () {
       final EmpireProperty<int> ageOne = viewModel.createProperty(10);
       final EmpireProperty<int> ageTwo = viewModel.createProperty(10);


### PR DESCRIPTION
Resolves #13 
- Added `equals` method to EmpireProperty to check equality of backing value
- Overrided the `==` operator