### PR TITLE
Null Check Properties on EmpireProperty

### DIFF
--- a/lib/empire_bool_property.dart
+++ b/lib/empire_bool_property.dart
@@ -24,7 +24,7 @@ class EmpireBoolProperty extends EmpireProperty<bool> {
 ///
 ///When the value of this changes, it will send a [EmpireStateChanged] event by default. This includes
 ///automatically triggering a UI rebuild.
-class EmpireNullableBoolProperty extends NullableEmpireProperty<bool?> {
+class EmpireNullableBoolProperty extends EmpireProperty<bool?> {
   EmpireNullableBoolProperty(super.value, super.viewModel, {super.propertyName});
 
   ///Whether the underlying value is not null and true

--- a/lib/empire_double_property.dart
+++ b/lib/empire_double_property.dart
@@ -120,7 +120,7 @@ class EmpireDoubleProperty extends EmpireProperty<double> {
 ///
 ///```
 ///
-class EmpireNullableDoubleProperty extends NullableEmpireProperty<double?> {
+class EmpireNullableDoubleProperty extends EmpireProperty<double?> {
   EmpireNullableDoubleProperty(super.value, super.viewModel, {super.propertyName});
 
   /// Whether this number is negative.

--- a/lib/empire_int_property.dart
+++ b/lib/empire_int_property.dart
@@ -92,7 +92,7 @@ class EmpireIntProperty extends EmpireProperty<int> {
 ///
 ///```
 ///
-class EmpireNullableIntProperty extends NullableEmpireProperty<int?> {
+class EmpireNullableIntProperty extends EmpireProperty<int?> {
   EmpireNullableIntProperty(super.value, super.viewModel, {super.propertyName});
 
   /// Returns true if the int value is odd

--- a/lib/empire_property.dart
+++ b/lib/empire_property.dart
@@ -52,6 +52,10 @@ class EmpireProperty<T> implements EmpireValue<T> {
   @override
   T get value => _value;
 
+  bool get isNull => _value == null;
+
+  bool get isNotNull => !isNull;
+
   final EmpireViewModel _viewModel;
 
   EmpireProperty(this._value, this._viewModel, {this.propertyName}) {

--- a/lib/empire_property.dart
+++ b/lib/empire_property.dart
@@ -138,11 +138,3 @@ class EmpireProperty<T> implements EmpireValue<T> {
   @override
   int get hashCode => _value.hashCode;
 }
-
-abstract class NullableEmpireProperty<T> extends EmpireProperty<T?> {
-  NullableEmpireProperty(super.value, super.viewModel, {super.propertyName});
-
-  bool get isNull => _value == null;
-
-  bool get isNotNull => _value != null;
-}

--- a/lib/empire_string_property.dart
+++ b/lib/empire_string_property.dart
@@ -56,7 +56,7 @@ class EmpireStringProperty extends EmpireProperty<String> {
 ///
 ///When the value of this changes, it will send a [EmpireStateChanged] event by default. This includes
 ///automatically triggering a UI rebuild.
-class EmpireNullableStringProperty extends NullableEmpireProperty<String?> {
+class EmpireNullableStringProperty extends EmpireProperty<String?> {
   EmpireNullableStringProperty(super.value, super.viewModel, {super.propertyName});
 
   ///Whether the string value is empty

--- a/test/empire_property_tests/empire_property_test.dart
+++ b/test/empire_property_tests/empire_property_test.dart
@@ -132,6 +132,26 @@ void main() {
       // ignore: unrelated_type_equality_checks
       expect(ageOne == name, isFalse);
     });
+
+    test('isNull - value is null - returns true', () {
+      final EmpireProperty<String?> nullName = viewModel.createNullProperty();
+      expect(nullName.isNull, isTrue);
+    });
+
+    test('isNull - value is not null - returns false', () {
+      final EmpireProperty<String> nullName = viewModel.createProperty('Bob');
+      expect(nullName.isNull, isFalse);
+    });
+
+    test('isNotNull - value is not null - returns true', () {
+      final EmpireProperty<String> nullName = viewModel.createProperty('Bob');
+      expect(nullName.isNotNull, isTrue);
+    });
+
+    test('isNotNull - value is null - returns false', () {
+      final EmpireProperty<String?> nullName = viewModel.createNullProperty();
+      expect(nullName.isNotNull, isFalse);
+    });
   });
 
   group('Property Reset Tests', () {


### PR DESCRIPTION
- Added `isNull` and `isNotNull` read-only properties on EmpireProperty for simplified null checks on dynamic property types