### PR TITLE
Fix Map Function on EmpireListProperty

### DIFF
--- a/lib/empire_list_property.dart
+++ b/lib/empire_list_property.dart
@@ -29,8 +29,8 @@ class EmpireListProperty<T> extends EmpireProperty<List<T>> {
   ///
   /// Example:
   /// ```dart
-  /// final emptyList = createListProperty<String>(['Bob'])
-  /// print(emptyList.isNotEmpty); // true;
+  /// final list = createListProperty<String>(['Bob'])
+  /// print(list.isNotEmpty); // true;
   /// ```
   bool get isNotEmpty => _value.isNotEmpty;
 

--- a/lib/empire_list_property.dart
+++ b/lib/empire_list_property.dart
@@ -16,6 +16,24 @@ class EmpireListProperty<T> extends EmpireProperty<List<T>> {
   /// ```
   int get length => _value.length;
 
+  /// Whether this value has no elements.
+  ///
+  /// Example:
+  /// ```dart
+  /// final emptyList = createEmptyListProperty<String>()
+  /// print(emptyList.isEmpty); // true;
+  /// ```
+  bool get isEmpty => _value.isEmpty;
+
+  /// Whether this value has no elements.
+  ///
+  /// Example:
+  /// ```dart
+  /// final emptyList = createListProperty<String>(['Bob'])
+  /// print(emptyList.isNotEmpty); // true;
+  /// ```
+  bool get isNotEmpty => _value.isNotEmpty;
+
   /// Adds [value] to the end of this list,
   /// extending the length by one.
   ///

--- a/lib/empire_list_property.dart
+++ b/lib/empire_list_property.dart
@@ -184,7 +184,7 @@ class EmpireListProperty<T> extends EmpireProperty<List<T>> {
   /// var values = products.map((product) => product['price'] as double);
   /// var totalPrice = values.fold(0.0, (a, b) => a + b); // 42.5.
   /// ```
-  Iterable<T> map(T Function(T) toElement) {
+  Iterable<E> map<E>(E Function(T) toElement) {
     return _value.map(toElement);
   }
 

--- a/test/empire_property_tests/list_property_test.dart
+++ b/test/empire_property_tests/list_property_test.dart
@@ -175,5 +175,16 @@ void main() {
 
       expect(result, equals(earth));
     });
+
+    test('map - generate different type in map function - returns correct values', () {
+      String earth = 'Earth';
+      String venus = 'Venus';
+
+      viewModel.planets.addAll([earth, venus]);
+
+      final results = viewModel.planets.map((planet) => planet.length).toList();
+
+      expect(results, const TypeMatcher<List<int>>());
+    });
   });
 }

--- a/test/empire_property_tests/list_property_test.dart
+++ b/test/empire_property_tests/list_property_test.dart
@@ -186,5 +186,29 @@ void main() {
 
       expect(results, const TypeMatcher<List<int>>());
     });
+
+    test('isEmpty - list is empty - returns true', () {
+      final emptyList = viewModel.createEmptyListProperty<String>();
+
+      expect(emptyList.isEmpty, isTrue);
+    });
+
+    test('isEmpty - list is not empty - returns false', () {
+      final emptyList = viewModel.createListProperty(['Bob']);
+
+      expect(emptyList.isEmpty, isFalse);
+    });
+
+    test('isNotEmpty - list is empty - returns false', () {
+      final list = viewModel.createEmptyListProperty<String>();
+
+      expect(list.isNotEmpty, isFalse);
+    });
+
+    test('isNotEmpty - list is not empty - returns true', () {
+      final list = viewModel.createListProperty(['Bob']);
+
+      expect(list.isNotEmpty, isTrue);
+    });
   });
 }


### PR DESCRIPTION
- Fix an issue where the wrong type of object was being returned when calling `map` on an EmpireListProperty