### PR TITLE
Fixed incorrect variable name in documentation

### DIFF
--- a/docs/empire_property/EmpireIntProperty-class.html
+++ b/docs/empire_property/EmpireIntProperty-class.html
@@ -64,7 +64,7 @@ late final EmpireIntProperty age;
 
 age = createIntProperty(10);
 
-print('${percentage + 5}'); //prints 15
+print('${age + 5}'); //prints 15
 </code></pre>
 </section>
 

--- a/lib/empire_int_property.dart
+++ b/lib/empire_int_property.dart
@@ -19,7 +19,7 @@ part of 'empire_property.dart';
 ///
 ///age = createIntProperty(10);
 ///
-///print('${percentage + 5}'); //prints 15
+///print('${age + 5}'); //prints 15
 ///```
 class EmpireIntProperty extends EmpireProperty<int> {
   EmpireIntProperty(super.value, super.viewModel, {super.propertyName});


### PR DESCRIPTION
closes #33 

Changed the variable name to fix an inconsistency in both the HTML docs and the comment in empire_int_property.dart