### PR TITLE
Fix internally tracked original values for list and map

### DIFF
--- a/lib/empire_list_property.dart
+++ b/lib/empire_list_property.dart
@@ -5,7 +5,9 @@ part of 'empire_property.dart';
 ///Any change to the internal list will send a [EmpireStateChanged] event by default. This includes
 ///automatically triggering a UI rebuild.
 class EmpireListProperty<T> extends EmpireProperty<List<T>> {
-  EmpireListProperty(super.value, super.viewModel, {super.propertyName});
+  EmpireListProperty(super.value, super.viewModel, {super.propertyName}) {
+    _originalValue = List<T>.from(value);
+  }
 
   /// The number of objects in this list.
   ///

--- a/lib/empire_map_property.dart
+++ b/lib/empire_map_property.dart
@@ -5,7 +5,9 @@ part of 'empire_property.dart';
 ///Any change to the internal map will send a [EmpireStateChanged] event by default. This includes
 ///automatically triggering a UI rebuild.
 class EmpireMapProperty<K, V> extends EmpireProperty<Map<K, V>> {
-  EmpireMapProperty(super.value, super.viewModel, {super.propertyName});
+  EmpireMapProperty(super.value, super.viewModel, {super.propertyName}) {
+    _originalValue = Map<K, V>.from(value);
+  }
 
   ///The map entries in the map
   Iterable<MapEntry<K, V>> get entries => _value.entries;

--- a/lib/empire_property.dart
+++ b/lib/empire_property.dart
@@ -16,12 +16,14 @@ abstract class EmpireValue<T> {
 
 ///Contains any object that will notify any listeners when its value is changed.
 ///
-///Usually these are
-///properties that are bound to a UI Widget so when the value changes, the UI is updated.
+///Usually these are properties that are bound to a UI Widget so when the value changes, the UI is updated.
 ///
 ///You optionally set the [propertyName] argument to conditionally perform logic when a specific
 ///property changes. You can access the [propertyName] in any event listener registered with the
 ///[EmpireViewModel.addOnStateChangedListener] function via the [propertyName] property on an [EmpireStateChanged] object.
+///
+///If [T] is of type [List] or [Map], use either [EmpireListProperty] or [EmpireMapProperty]. Not doing so
+///will prevet the [reset] function from performing as expected.
 ///
 ///An [EmpireProperty] is callable. Calling the property updates the value. However, there are two
 ///ways to update the value of an [EmpireProperty]:
@@ -47,8 +49,12 @@ abstract class EmpireValue<T> {
 ///```
 class EmpireProperty<T> implements EmpireValue<T> {
   String? propertyName;
+
+  late T _originalValue;
+  T get originalValue => _originalValue;
+
   T _value;
-  late final T _originalValue;
+
   @override
   T get value => _value;
 
@@ -79,6 +85,11 @@ class EmpireProperty<T> implements EmpireValue<T> {
   }
 
   ///Resets the value to what it was initialized with.
+  ///
+  ///If [T] is a  class with properties, changing the properties directly on the object
+  ///instead of updating this EmpireProperty with a new instance of [T] with the updated values will
+  ///prevent [reset] from performing as expected. Tracking the original value is done by reference
+  ///internally.
   ///
   ///## Usage
   ///

--- a/lib/empire_view_model.dart
+++ b/lib/empire_view_model.dart
@@ -285,7 +285,7 @@ abstract class EmpireViewModel {
   ///
   ///planet = createMapProperty<String, dynamic>({'name': 'Earth', 'population': 8000000000});
   ///```
-  EmpireMapProperty createMapProperty<K, V>(Map<K, V> values, {String? propertyName}) {
+  EmpireMapProperty<K, V> createMapProperty<K, V>(Map<K, V> values, {String? propertyName}) {
     return EmpireMapProperty(values, this, propertyName: propertyName);
   }
 

--- a/test/empire_property_tests/list_property_test.dart
+++ b/test/empire_property_tests/list_property_test.dart
@@ -210,5 +210,27 @@ void main() {
 
       expect(list.isNotEmpty, isTrue);
     });
+
+    test('reset - starting list is empty - add item - should be empty after reset', () {
+      final list = viewModel.createEmptyListProperty<String>();
+      list.add('Bob');
+      list.reset();
+      expect(list.isEmpty, isTrue);
+    });
+
+    test('reset - starting list has data - remove item - only original data after reset', () {
+      const String listItem = 'Earth';
+      final data = viewModel.createListProperty<String>([listItem]);
+
+      expect(data.contains(listItem), isTrue);
+
+      data.clear();
+
+      expect(data.contains(listItem), isFalse);
+
+      data.reset();
+
+      expect(data.contains(listItem), isTrue);
+    });
   });
 }

--- a/test/empire_property_tests/map_property_test.dart
+++ b/test/empire_property_tests/map_property_test.dart
@@ -380,21 +380,26 @@ void main() {
       expect(data.isEmpty, isTrue);
     });
 
-    test('reset - starting map has data - remove item - only original data after reset', () {
-      const String key = 'name';
+    test('reset - starting map has data - add item - only original data after reset', () {
+      const String key = 'firstName';
       const String value = 'Bob';
+      const String tmpKey = 'lastName';
+      const String tmpValue = 'Smith';
+
       final data = viewModel.createMapProperty<String, String>({key: value});
 
       expect(data.containsKey(key), isTrue);
       expect(data.containsValue(value), isTrue);
 
-      data.clear();
+      data.add(tmpKey, tmpValue);
 
-      expect(data.containsKey(key), isFalse);
-      expect(data.containsValue(value), isFalse);
+      expect(data.containsKey(tmpKey), isTrue);
+      expect(data.containsValue(tmpValue), isTrue);
 
       data.reset();
 
+      expect(data.containsKey(tmpKey), isFalse);
+      expect(data.containsValue(tmpValue), isFalse);
       expect(data.containsKey(key), isTrue);
       expect(data.containsValue(value), isTrue);
     });

--- a/test/empire_property_tests/map_property_test.dart
+++ b/test/empire_property_tests/map_property_test.dart
@@ -369,5 +369,34 @@ void main() {
 
       expect(result, isNull);
     });
+    test('reset - starting map is empty - add item - should be empty after reset', () {
+      final data = viewModel.createEmptyMapProperty<String, String>();
+      data.add('name', 'Bob');
+
+      expect(data.isNotEmpty, isTrue);
+
+      data.reset();
+
+      expect(data.isEmpty, isTrue);
+    });
+
+    test('reset - starting map has data - remove item - only original data after reset', () {
+      const String key = 'name';
+      const String value = 'Bob';
+      final data = viewModel.createMapProperty<String, String>({key: value});
+
+      expect(data.containsKey(key), isTrue);
+      expect(data.containsValue(value), isTrue);
+
+      data.clear();
+
+      expect(data.containsKey(key), isFalse);
+      expect(data.containsValue(value), isFalse);
+
+      data.reset();
+
+      expect(data.containsKey(key), isTrue);
+      expect(data.containsValue(value), isTrue);
+    });
   });
 }


### PR DESCRIPTION
Resolves #36 

- Now creating a copy of the initial list for `EmpireListProperty` or the initial map for `EmpireMapProperty`. This ensures the `reset` function performs correctly for these types
- Also fixed a bug in the return type for the `createMapProperty` function on the EmpireViewModel