### PR TITLE
Allow Updating Original Value on Empire Property

### DIFF
--- a/lib/empire_property.dart
+++ b/lib/empire_property.dart
@@ -72,6 +72,32 @@ class EmpireProperty<T> implements EmpireValue<T> {
     set(value, notifyChange: notifyChange);
   }
 
+  ///Updates the original value to what the current value of this property is.
+  ///
+  ///If this function is called, the [reset] function will then use the updated
+  ///original value to set the current value
+  ///
+  ///## Example
+  ///```dart
+  ///final user = createNullProperty<User>();
+  ///
+  ///user(await userService.loadUser());
+  ///
+  ///user.reset(); //user value would be reset to null
+  ///
+  ///user(await userService.loadUser());
+  ///
+  ///user.setOriginalValueToCurrent();
+  ///
+  ///user(null);
+  ///
+  ///user.reset(); //user value would be reset to the user returned from the userService
+  ///
+  ///```
+  void setOriginalValueToCurrent() {
+    _originalValue = _value;
+  }
+
   ///Updates the property value. Notifies any listeners to the change
   ///
   ///Returns the updated value

--- a/test/empire_property_tests/empire_property_test.dart
+++ b/test/empire_property_tests/empire_property_test.dart
@@ -154,6 +154,26 @@ void main() {
     });
   });
 
+  group('Property Original Value Tests', () {
+    test('setOriginalToCurrent - update original value - reset sets value to updated original ', () {
+      const String expectedValue = 'Bob';
+      final EmpireProperty<String?> name = viewModel.createNullProperty();
+
+      name(expectedValue);
+
+      expect(name.value, equals(expectedValue));
+
+      name.reset();
+
+      expect(name.isNull, isTrue);
+
+      name(expectedValue);
+      name.setOriginalValueToCurrent();
+      name.reset();
+
+      expect(name.value, equals(expectedValue));
+    });
+  });
   group('Property Reset Tests', () {
     testWidgets('reset - notifyChange is true - UI Updates', (tester) async {
       await tester.pumpWidget(testWidget);


### PR DESCRIPTION
 - Added `setOriginalToCurrent` function on EmpireProperty. This is to support scenarios where when you create your property you may want it nullable, then do some async call the fetch the value for your property and you want that value to be your original. This means when you call reset after calling `setOriginalToCurrent` it would get reset to the value from your fetch.