### PR TITLE
Fix BusyTaskKey Bug

### DIFF
--- a/lib/empire_view_model.dart
+++ b/lib/empire_view_model.dart
@@ -191,7 +191,7 @@ abstract class EmpireViewModel {
   bool isTaskInProgress(dynamic busyTaskKey) => _busyTaskKeys.contains(busyTaskKey);
 
   void _addBusyTaskKey(dynamic busyTaskKey) {
-    if (busyTaskKey != null) {
+    if (busyTaskKey != null && !_busyTaskKeys.contains(busyTaskKey)) {
       _busyTaskKeys.add(busyTaskKey);
     }
   }

--- a/lib/empire_widget.dart
+++ b/lib/empire_widget.dart
@@ -127,9 +127,11 @@ class _EmpireState<T extends EmpireViewModel> extends State<Empire> {
         // ignore: avoid_print
         events.forEach(print);
       }
-      setState(() {
-        _applicationStateId = widget.onAppStateChanged();
-      });
+      if (mounted) {
+        setState(() {
+          _applicationStateId = widget.onAppStateChanged();
+        });
+      }
     });
     super.initState();
   }


### PR DESCRIPTION
- Only add a busyTaskKey to the internal list if the key doesn't already exist in the list
- Added a `mounted` check on the EmpireState class. This is to prevent `setState` from getting called in situations where the Flutter may have already unmounted the widget from the tree.