### PR TITLE
Set multiple doesn't work when Empire Property keys have null values

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "dart.lineLength": 110
+}

--- a/lib/empire_view_model.dart
+++ b/lib/empire_view_model.dart
@@ -91,8 +91,8 @@ abstract class EmpireViewModel {
 
   ///Set multiple [EmpireProperty] values, but only trigger a single state change
   ///
-  ///The [setters] keys should be the properties you want to set. The values should be the new
-  ///values for each property.
+  ///The [setters] is a list of maps, where the keys are the properties you want to set, and the values are the new
+  ///values for each property. Each map in the list must contain exactly one key/value pair.
   ///
   ///## Usage
   ///

--- a/lib/empire_view_model.dart
+++ b/lib/empire_view_model.dart
@@ -100,13 +100,19 @@ abstract class EmpireViewModel {
   ///late final EmpireProperty<String> name;
   ///late final EmpireProperty<int> age;
   ///
-  ///setMultiple({name: 'Doug', age: 45});
+  ///setMultiple([
+  ///   {name: 'Doug'},
+  ///   {age: 45},
+  ///]);
   ///```
-  void setMultiple(Map<EmpireProperty, dynamic> setters) {
+  void setMultiple(List<Map<EmpireProperty, dynamic>> setters) {
     final List<EmpireStateChanged> changes = [];
-    for (var property in setters.keys) {
+    for (var setter in setters) {
+      assert(setter.keys.length == 1, 'Each setter item must contain exactly one key/value pair.');
+      final property = setter.keys.first;
+
       final previousValue = property.value;
-      final nextValue = setters[property];
+      final nextValue = setter.values.first;
 
       changes.add(EmpireStateChanged(nextValue, previousValue, propertyName: property.propertyName));
 

--- a/test/empire_widget_test.dart
+++ b/test/empire_widget_test.dart
@@ -68,8 +68,7 @@ class _MyWidgetState extends EmpireState<_MyWidget, _TestViewModel> {
             builder: (outerContext) {
               return Empire(
                 widget.appSubViewModel,
-                onAppStateChanged: () =>
-                    math.Random().nextInt(1000000).toString(),
+                onAppStateChanged: () => math.Random().nextInt(1000000).toString(),
                 child: Builder(builder: (innerContext) {
                   return Center(
                     child: Column(
@@ -79,10 +78,8 @@ class _MyWidgetState extends EmpireState<_MyWidget, _TestViewModel> {
                         Text(
                           viewModel.age.value.toString(),
                         ),
-                        Text(
-                            '${Empire.of<_ApplicationViewModel>(outerContext).viewModel().changed}'),
-                        Text(
-                            '${Empire.of<_ApplicationSubViewModel>(innerContext).viewModel().viewModelName}')
+                        Text('${Empire.of<_ApplicationViewModel>(outerContext).viewModel().changed}'),
+                        Text('${Empire.of<_ApplicationSubViewModel>(innerContext).viewModel().viewModelName}')
                       ],
                     ),
                   );
@@ -112,9 +109,7 @@ void main() {
     );
   });
 
-  testWidgets(
-      'EmpireWidget Test - Finds Correct Text Widget After Property Change',
-      (tester) async {
+  testWidgets('EmpireWidget Test - Finds Correct Text Widget After Property Change', (tester) async {
     viewModel.firstName("John");
     await tester.pumpWidget(mainWidget);
 
@@ -126,8 +121,7 @@ void main() {
     expect(find.text("Bob"), findsOneWidget);
   });
 
-  testWidgets('Empire App State Test - Widgets Update on App View Model Change',
-      (tester) async {
+  testWidgets('Empire App State Test - Widgets Update on App View Model Change', (tester) async {
     await tester.pumpWidget(mainWidget);
 
     final text = find.text("false");
@@ -141,8 +135,7 @@ void main() {
     expect(textTwo, findsOneWidget);
   });
 
-  testWidgets('Update More Than One Property - All Widgets Update',
-      (tester) async {
+  testWidgets('Update More Than One Property - All Widgets Update', (tester) async {
     const initialFirstName = 'John';
     const initialLastName = 'Smith';
     const initialAge = 88;
@@ -161,11 +154,11 @@ void main() {
     const newLastName = 'Brown';
     const newAge = 20;
 
-    viewModel.setMultiple({
-      viewModel.firstName: newFirstName,
-      viewModel.lastName: newLastName,
-      viewModel.age: newAge,
-    });
+    viewModel.setMultiple([
+      {viewModel.firstName: newFirstName},
+      {viewModel.lastName: newLastName},
+      {viewModel.age: newAge},
+    ]);
 
     await tester.pumpAndSettle();
 
@@ -174,20 +167,18 @@ void main() {
     expect(find.text(newAge.toString()), findsOneWidget);
   });
 
-  testWidgets(
-      'Update More Than One Property Starting from Null Keys - All Widgets Update',
-      (tester) async {
+  testWidgets('Update More Than One Property Starting from Null Keys - All Widgets Update', (tester) async {
     await tester.pumpWidget(mainWidget);
 
     const newFirstName = 'Bob';
     const newLastName = 'Brown';
     const newAge = 20;
 
-    viewModel.setMultiple({
-      viewModel.firstName: newFirstName,
-      viewModel.lastName: newLastName,
-      viewModel.age: newAge,
-    });
+    viewModel.setMultiple([
+      {viewModel.firstName: newFirstName},
+      {viewModel.lastName: newLastName},
+      {viewModel.age: newAge},
+    ]);
 
     await tester.pumpAndSettle();
 
@@ -196,15 +187,13 @@ void main() {
     expect(find.text(newAge.toString()), findsOneWidget);
   });
 
-  testWidgets('EmpireWidget Test - Finds Sub Application View Model',
-      (tester) async {
+  testWidgets('EmpireWidget Test - Finds Sub Application View Model', (tester) async {
     await tester.pumpWidget(mainWidget);
 
     expect(find.text(subViewModel.viewModelName.value), findsOneWidget);
   });
 
-  testWidgets('EmpireWidget Test - Finds Sub Application View Model',
-      (tester) async {
+  testWidgets('EmpireWidget Test - Finds Sub Application View Model', (tester) async {
     await tester.pumpWidget(mainWidget);
 
     expect(find.text(subViewModel.viewModelName.value), findsOneWidget);

--- a/test/empire_widget_test.dart
+++ b/test/empire_widget_test.dart
@@ -68,7 +68,8 @@ class _MyWidgetState extends EmpireState<_MyWidget, _TestViewModel> {
             builder: (outerContext) {
               return Empire(
                 widget.appSubViewModel,
-                onAppStateChanged: () => math.Random().nextInt(1000000).toString(),
+                onAppStateChanged: () =>
+                    math.Random().nextInt(1000000).toString(),
                 child: Builder(builder: (innerContext) {
                   return Center(
                     child: Column(
@@ -78,8 +79,10 @@ class _MyWidgetState extends EmpireState<_MyWidget, _TestViewModel> {
                         Text(
                           viewModel.age.value.toString(),
                         ),
-                        Text('${Empire.of<_ApplicationViewModel>(outerContext).viewModel().changed}'),
-                        Text('${Empire.of<_ApplicationSubViewModel>(innerContext).viewModel().viewModelName}')
+                        Text(
+                            '${Empire.of<_ApplicationViewModel>(outerContext).viewModel().changed}'),
+                        Text(
+                            '${Empire.of<_ApplicationSubViewModel>(innerContext).viewModel().viewModelName}')
                       ],
                     ),
                   );
@@ -109,7 +112,9 @@ void main() {
     );
   });
 
-  testWidgets('EmpireWidget Test - Finds Correct Text Widget After Property Change', (tester) async {
+  testWidgets(
+      'EmpireWidget Test - Finds Correct Text Widget After Property Change',
+      (tester) async {
     viewModel.firstName("John");
     await tester.pumpWidget(mainWidget);
 
@@ -121,7 +126,8 @@ void main() {
     expect(find.text("Bob"), findsOneWidget);
   });
 
-  testWidgets('Empire App State Test - Widgets Update on App View Model Change', (tester) async {
+  testWidgets('Empire App State Test - Widgets Update on App View Model Change',
+      (tester) async {
     await tester.pumpWidget(mainWidget);
 
     final text = find.text("false");
@@ -135,7 +141,8 @@ void main() {
     expect(textTwo, findsOneWidget);
   });
 
-  testWidgets('Update More Than One Property - All Widgets Update', (tester) async {
+  testWidgets('Update More Than One Property - All Widgets Update',
+      (tester) async {
     const initialFirstName = 'John';
     const initialLastName = 'Smith';
     const initialAge = 88;
@@ -167,13 +174,37 @@ void main() {
     expect(find.text(newAge.toString()), findsOneWidget);
   });
 
-  testWidgets('EmpireWidget Test - Finds Sub Application View Model', (tester) async {
+  testWidgets(
+      'Update More Than One Property Starting from Null Keys - All Widgets Update',
+      (tester) async {
+    await tester.pumpWidget(mainWidget);
+
+    const newFirstName = 'Bob';
+    const newLastName = 'Brown';
+    const newAge = 20;
+
+    viewModel.setMultiple({
+      viewModel.firstName: newFirstName,
+      viewModel.lastName: newLastName,
+      viewModel.age: newAge,
+    });
+
+    await tester.pumpAndSettle();
+
+    expect(find.text(newFirstName), findsOneWidget);
+    expect(find.text(newLastName), findsOneWidget);
+    expect(find.text(newAge.toString()), findsOneWidget);
+  });
+
+  testWidgets('EmpireWidget Test - Finds Sub Application View Model',
+      (tester) async {
     await tester.pumpWidget(mainWidget);
 
     expect(find.text(subViewModel.viewModelName.value), findsOneWidget);
   });
 
-  testWidgets('EmpireWidget Test - Finds Sub Application View Model', (tester) async {
+  testWidgets('EmpireWidget Test - Finds Sub Application View Model',
+      (tester) async {
     await tester.pumpWidget(mainWidget);
 
     expect(find.text(subViewModel.viewModelName.value), findsOneWidget);


### PR DESCRIPTION
This is caused by a quirk in how dart deals with map initializers.

If you create two Empire Properties which start out as null, then use set multiple to update them, dart considers the keys to be equal and will end up condensing the map down to a single key, which will result in either incorrect behavior (if the values are the same type) or a crash (if the values are incompatible).

A change to the syntax of setMultiple was required to fix this.